### PR TITLE
Fix link format for main image/embedded images

### DIFF
--- a/content/service.go
+++ b/content/service.go
@@ -55,7 +55,10 @@ func (u *ContentUnroller) UnrollContent(req UnrollEvent) UnrollResult {
 
 		mainImageUUID := schema.get(mainImage)
 		if mainImageUUID != "" {
-			cc[mainImage] = contentMap[mainImageUUID]
+			expMainImage := contentMap[mainImageUUID]
+			if expMainImage != nil {
+				cc[mainImage] = expMainImage
+			}
 		}
 
 		embeddedContentUUIDs := schema.getAll(embeds)
@@ -291,17 +294,15 @@ func (u *ContentUnroller) unrollDynamicContent(cc Content, tid string, uuid stri
 }
 
 func (u *ContentUnroller) resolveModelsForSetsMembers(b ContentSchema, imgMap map[string]Content, tid string, uuid string) {
-	mainImageUUID := b.get(mainImage)
-	u.resolveImageSet(mainImageUUID, imgMap, tid, uuid)
-	for _, embeddedImgSet := range b.getAll(embeds) {
-		u.resolveImageSet(embeddedImgSet, imgMap, tid, uuid)
+	for _, embeddedImgSetUUID := range b.getAll(embeds) {
+		u.resolveImageSet(embeddedImgSetUUID, imgMap, tid, uuid)
 	}
 }
 
 func (u *ContentUnroller) resolveImageSet(imageSetUUID string, imgMap map[string]Content, tid string, uuid string) {
 	imageSet, found := u.resolveContent(imageSetUUID, imgMap)
 	if !found {
-		imgMap[imageSetUUID] = Content{id: createID(u.apiHost, "content", imageSetUUID)}
+		imgMap[imageSetUUID] = Content{id: createID(u.apiHost, "", imageSetUUID)}
 		return
 	}
 

--- a/content/service.go
+++ b/content/service.go
@@ -26,18 +26,16 @@ type Unroller interface {
 }
 
 type ContentUnroller struct {
-	reader  Reader
-	apiHost string
+	reader Reader
 }
 
 type Content map[string]interface{}
 
 type ContentSchema map[string][]string
 
-func NewContentUnroller(r Reader, apiHost string) *ContentUnroller {
+func NewContentUnroller(r Reader) *ContentUnroller {
 	return &ContentUnroller{
-		reader:  r,
-		apiHost: apiHost,
+		reader: r,
 	}
 }
 
@@ -302,7 +300,7 @@ func (u *ContentUnroller) resolveModelsForSetsMembers(b ContentSchema, imgMap ma
 func (u *ContentUnroller) resolveImageSet(imageSetUUID string, imgMap map[string]Content, tid string, uuid string) {
 	imageSet, found := u.resolveContent(imageSetUUID, imgMap)
 	if !found {
-		imgMap[imageSetUUID] = Content{id: createID(u.apiHost, "", imageSetUUID)}
+		imgMap[imageSetUUID] = Content{id: createID(imageSetUUID)}
 		return
 	}
 

--- a/content/service_test.go
+++ b/content/service_test.go
@@ -49,7 +49,6 @@ func TestUnrollContent(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	expected, err := ioutil.ReadFile("../test-resources/content-valid-response.json")
@@ -88,7 +87,6 @@ func TestUnrollContent_ErrorExpandingFromContentStore(t *testing.T) {
 				return nil, errors.New("Cannot expand content from content store")
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -122,7 +120,6 @@ func TestUnrollContent_SkipPromotionalImageWhenIdIsMissing(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -155,7 +152,6 @@ func TestUnrollContent_SkipPromotionalImageWhenUUIDIsInvalid(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -182,7 +178,6 @@ func TestUnrollContent_EmbeddedContentSkippedWhenMissingBodyXML(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -195,6 +190,37 @@ func TestUnrollContent_EmbeddedContentSkippedWhenMissingBodyXML(t *testing.T) {
 	res := cu.UnrollContent(req)
 	assert.NoError(t, res.err, "Should not receive error when body cannot be parsed.")
 	assert.Nil(t, res.uc["embeds"], "Response should not contain embeds field")
+}
+
+func TestUnrollContent_EmbeddedContentNotResolved(t *testing.T) {
+	cu := ContentUnroller{
+		reader: &ReaderMock{
+			mockGet: func(c []string, tid string) (map[string]Content, error) {
+				b, err := ioutil.ReadFile("../test-resources/reader-content-valid-response-embeds-not-resolved.json")
+				assert.NoError(t, err, "Cannot open file necessary for test case")
+				var res map[string]Content
+				err = json.Unmarshal(b, &res)
+				assert.NoError(t, err, "Cannot return valid response")
+				return res, nil
+			},
+		},
+	}
+
+	expected, err := ioutil.ReadFile("../test-resources/content-valid-response-embeds-not-resolved.json")
+	assert.NoError(t, err, "Cannot read necessary test file")
+
+	var c Content
+	fileBytes, err := ioutil.ReadFile("../test-resources/content-valid-request.json")
+	assert.NoError(t, err, "Cannot read necessary test file")
+	err = json.Unmarshal(fileBytes, &c)
+	assert.NoError(t, err, "Cannot build json body")
+
+	req := UnrollEvent{c, "tid_sample", "sample_uuid"}
+	actual := cu.UnrollContent(req)
+	assert.NoError(t, actual.err, "Should not get an error when expanding images")
+
+	actualJSON, err := json.Marshal(actual.uc)
+	assert.JSONEq(t, string(expected), string(actualJSON))
 }
 
 func TestUnrollInternalContent(t *testing.T) {
@@ -217,7 +243,6 @@ func TestUnrollInternalContent(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -251,7 +276,6 @@ func TestUnrollInternalContent_LeadImagesSkippedWhenReadingError(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -285,7 +309,6 @@ func TestUnrollInternalContent_DynamicContentSkippedWhenReadingError(t *testing.
 				return nil, errors.New("Error retrieving content")
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -324,7 +347,6 @@ func TestUnrollContentPreview(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	expected, err := ioutil.ReadFile("../test-resources/contentpreview-valid-response.json")
@@ -377,7 +399,6 @@ func TestUnrollContentPreview_ErrorExpandingImages(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	expected, err := ioutil.ReadFile("../test-resources/contentpreview-noimages-valid-response.json")
@@ -405,7 +426,6 @@ func TestUnrollContentPreview_ErrorExpandingImagesAndDynamicContent(t *testing.T
 				return nil, errors.New("Cannot expand content from content store")
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -440,7 +460,6 @@ func TestUnrollInternalContentPreview(t *testing.T) {
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content
@@ -474,7 +493,6 @@ func TestUnrollInternalContentPreview_LeadImagesSkippedWhenReadingError(t *testi
 				return res, nil
 			},
 		},
-		apiHost: "test.api.ft.com",
 	}
 
 	var c Content

--- a/content/uuid.go
+++ b/content/uuid.go
@@ -6,7 +6,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const uuidRegex = "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+const (
+	uuidRegex        = "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+	uuidFormatPrefix = "http://www.ft.com/thing/"
+)
 
 func extractUUIDFromString(url string) (string, error) {
 	re, err := regexp.Compile(uuidRegex)
@@ -21,6 +24,6 @@ func extractUUIDFromString(url string) (string, error) {
 	return "", errors.Errorf("Cannot extract UUID from %s", url)
 }
 
-func createID(APIHost string, handlerPath string, uuid string) string {
-	return "http://" + APIHost + "/" + handlerPath + "/" + uuid
+func createID(uuid string) string {
+	return uuidFormatPrefix + uuid
 }

--- a/helm/content-unroller/templates/deployment.yaml
+++ b/helm/content-unroller/templates/deployment.yaml
@@ -48,10 +48,7 @@ spec:
         - name: INTERNAL_CONTENT_PATH
           value: {{ .Values.internal_content_path }}
         - name: API_HOST
-          valueFrom:
-            configMapKeyRef:
-              name: global-config
-              key: api.host
+          value: {{ .Values.api_host }}
         ports: 
         - containerPort: 8080 
         livenessProbe: 

--- a/helm/content-unroller/templates/deployment.yaml
+++ b/helm/content-unroller/templates/deployment.yaml
@@ -47,8 +47,6 @@ spec:
           value:  {{ .Values.content_path }}
         - name: INTERNAL_CONTENT_PATH
           value: {{ .Values.internal_content_path }}
-        - name: API_HOST
-          value: {{ .Values.api_host }}
         ports: 
         - containerPort: 8080 
         livenessProbe: 

--- a/main.go
+++ b/main.go
@@ -67,12 +67,6 @@ func main() {
 		Desc:   "/internalcontent path",
 		EnvVar: "INTERNAL_CONTENT_PATH",
 	})
-	apiHost := app.String(cli.StringOpt{
-		Name:   "apiHost",
-		Value:  "www.ft.com/thing",
-		Desc:   "API host to use for URLs in responses",
-		EnvVar: "API_HOST",
-	})
 
 	app.Action = func() {
 		httpClient := &http.Client{
@@ -103,7 +97,7 @@ func main() {
 		}
 
 		reader := content.NewContentReader(readerConfig, httpClient)
-		unroller := content.NewContentUnroller(reader, *apiHost)
+		unroller := content.NewContentUnroller(reader)
 
 		h := setupServiceHandler(unroller, sc)
 		err := http.ListenAndServe(":"+*port, h)

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	})
 	apiHost := app.String(cli.StringOpt{
 		Name:   "apiHost",
-		Value:  "test.api.ft.com",
+		Value:  "www.ft.com/thing",
 		Desc:   "API host to use for URLs in responses",
 		EnvVar: "API_HOST",
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -85,7 +85,7 @@ func startUnrollerService(contentStoreURL string, contentPreviewURL string) {
 	}
 
 	reader := content.NewContentReader(rc, http.DefaultClient)
-	unroller := content.NewContentUnroller(reader, "test.api.ft.com")
+	unroller := content.NewContentUnroller(reader)
 
 	h := setupServiceHandler(unroller, sc)
 	unrollerService = httptest.NewServer(h)

--- a/test-resources/content-valid-request.json
+++ b/test-resources/content-valid-request.json
@@ -21,7 +21,8 @@
       "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
     ],
     "mainImage": {
-      "id": "http://api.ft.com/content/639cd952-149f-11e7-2ea7-a07ecd9ac73f"
+	  "id": "http://www.ft.com/thing/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+	  "apiUrl": "https://test.api.ft.com/content/b7c8e40e-73a7-11e8-17fc-56e8d19c9a20"
     },
     "alternativeImages": {
       "promotionalImage": {

--- a/test-resources/content-valid-response-embeds-not-resolved.json
+++ b/test-resources/content-valid-response-embeds-not-resolved.json
@@ -1,0 +1,246 @@
+{
+    "accessLevel": "subscribed",
+    "alternativeImages": {
+      "promotionalImage": {
+        "alternativeImages": {},
+        "alternativeStandfirsts": {},
+        "alternativeTitles": {},
+        "binaryUrl": "http://image-storage-location",
+        "id": "http://www.ft.com/thing/4723cb4e-027c-11e7-ace0-1ce02ef0def9",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "4723cb4e-027c-11e7-ace0-1ce02ef0def9"
+          }
+        ],
+        "lastModified": "2017-03-06T14:50:50.298Z",
+        "publishReference": "tid_axufgrmrhm",
+        "publishedDate": "2017-03-06T14:50:00.000Z",
+        "requestUrl": "http://api.ft.com/content/4723cb4e-027c-11e7-ace0-1ce02ef0def9",
+        "type": "http://www.ft.com/ontology/content/MediaResource"
+      }
+    },
+    "alternativeStandfirsts": {},
+    "alternativeTitles": {
+      "promotionalTitle": "Brexit begins as Theresa May triggers Article 50"
+    },
+    "bodyXML": "<body><ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://api.ft.com/content/639cd952-149f-11e7-2ea7-a07ecd9ac73f\" data-embedded=\"true\"></ft-content><p>But the government’s approach drew some criticism at home. Nick Macpherson, the former Treasury permanent secretary, tweeted: “Crime and terrorism don’t respect borders. It is not a credible threat to link co-operation to a trade deal.”</p>\n<ft-related type=\"http://www.ft.com/ontology/content/Article\" url=\"http://api.ft.com/content/1888b166-13b9-11e7-80f4-13e067d5072c\"><title>Read more</title><headline>Brexit Article 50 letter — annotated transcript\n</headline><media><ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://api.ft.com/content/71231d3a-13c7-11e7-2ea7-a07ecd9ac73f\" data-embedded=\"true\"></ft-content></media><intro><p>FT journalists explain the key passages of the UK government’s letter triggering the exit process</p></intro></ft-related>\n<p>Germany said the negotiations would not be easy for either side. Chancellor Angela Merkel took a<ft-content type=\"http://www.ft.com/ontology/content/Article\" url=\"http://api.ft.com/content/4855afce-10a4-11e7-b030-768954394623\">hard line</ft-content> on the sequencing of the talks, saying Britain’s future relationship with the EU could be discussed only after a divorce settlement is reached on the terms of Britain’s exit, which is expected to include the €60bn Brussels believes the UK still owes the EU.</p>\n<ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://api.ft.com/content/0261ea4a-1474-11e7-1e92-847abda1ac65\" data-embedded=\"true\"></ft-content>\n<p>The prime minister of Croatia — the last country to join the EU, in 2013 — said Brexit was a “big, huge mistake” with negative consequences that will be felt primarily in Britain. Andrej Plenkovic said “no one can tell at this moment” when the negotiation would end, and what kind of agreement it would produce.</p>\n<ft-content type=\"http://www.ft.com/ontology/content/MediaResource\" url=\"http://api.ft.com/content/da0e3d5d-ccf0-3b40-b865-f648189fb849\" data-embedded=\"true\"></ft-content><ft-content data-embedded=\"true\" type=\"http://www.ft.com/ontology/content/DynamicContent\" url=\"http://test.api.ft.com/content/d02886fc-58ff-11e8-9859-6668838a4c10\"></ft-content>\n\n\n</body>",
+    "brands": [
+      "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+    ],
+    "byline": "George Parker and Kate Allen in London and Arthur Beesley in Brussels",
+    "canBeDistributed": "yes",
+    "canBeSyndicated": "yes",
+    "comments": {
+      "enabled": true
+    },
+    "embeds": [
+      {
+        "alternativeImages": {},
+        "alternativeStandfirsts": {},
+        "alternativeTitles": {},
+        "canBeDistributed": "verify",
+        "description": "sample description",
+        "id": "http://www.ft.com/thing/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "639cd952-149f-11e7-2ea7-a07ecd9ac73f"
+          }
+        ],
+        "lastModified": "2017-03-29T19:39:31.361Z",
+        "members": [
+          {
+            "alternativeImages": {},
+            "alternativeStandfirsts": {},
+            "alternativeTitles": {},
+            "binaryUrl": "http://image-storage-location",
+            "canBeDistributed": "verify",
+            "copyright": {
+              "notice": "© Bloomberg"
+            },
+            "description": "sample description",
+            "id": "http://www.ft.com/thing/639cd952-149f-11e7-b0c1-37e417ee6c76",
+            "identifiers": [
+              {
+                "authority": "http://api.ft.com/system/FTCOM-METHODE",
+                "identifierValue": "639cd952-149f-11e7-b0c1-37e417ee6c76"
+              }
+            ],
+            "lastModified": "2017-03-29T19:39:31.361Z",
+            "pixelHeight": 1152,
+            "pixelWidth": 2048,
+            "publishReference": "tid_5ypvntzcpu",
+            "publishedDate": "2017-03-29T19:39:00.000Z",
+            "requestUrl": "http://api.ft.com/content/639cd952-149f-11e7-b0c1-37e417ee6c76",
+            "title": "",
+            "type": "http://www.ft.com/ontology/content/MediaResource"
+          }
+        ],
+        "publishReference": "tid_5ypvntzcpu",
+        "publishedDate": "2017-03-29T19:39:00.000Z",
+        "requestUrl": "http://api.ft.com/content/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+        "title": "",
+        "type": "http://www.ft.com/ontology/content/ImageSet"
+	  },
+	  {
+		"id": "http://www.ft.com/thing/71231d3a-13c7-11e7-2ea7-a07ecd9ac73f"
+	  },
+      {
+        "alternativeImages": {},
+        "alternativeStandfirsts": {},
+        "alternativeTitles": {},
+        "canBeDistributed": "verify",
+        "description": "sample description",
+        "id": "http://www.ft.com/thing/0261ea4a-1474-11e7-1e92-847abda1ac65",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "0261ea4a-1474-11e7-1e92-847abda1ac65"
+          }
+        ],
+        "lastModified": "2017-03-29T18:28:38.623Z",
+        "members": [
+          {
+            "alternativeImages": {},
+            "alternativeStandfirsts": {},
+            "alternativeTitles": {},
+            "binaryUrl": "http://image-storage-location",
+            "canBeDistributed": "verify",
+            "copyright": {
+              "notice": "© AFP"
+            },
+            "description": "sample description",
+            "id": "http://www.ft.com/thing/0261ea4a-1474-11e7-80f4-13e067d5072c",
+            "identifiers": [
+              {
+                "authority": "http://api.ft.com/system/FTCOM-METHODE",
+                "identifierValue": "0261ea4a-1474-11e7-80f4-13e067d5072c"
+              }
+            ],
+            "lastModified": "2017-03-29T18:28:38.623Z",
+            "pixelHeight": 1152,
+            "pixelWidth": 2048,
+            "publishReference": "tid_4tjlxfiynp",
+            "publishedDate": "2017-03-29T18:28:00.000Z",
+            "requestUrl": "http://api.ft.com/content/0261ea4a-1474-11e7-80f4-13e067d5072c",
+            "title": "",
+            "type": "http://www.ft.com/ontology/content/MediaResource"
+          }
+        ],
+        "publishReference": "tid_4tjlxfiynp",
+        "publishedDate": "2017-03-29T18:28:00.000Z",
+        "requestUrl": "http://api.ft.com/content/0261ea4a-1474-11e7-1e92-847abda1ac65",
+        "title": "",
+        "type": "http://www.ft.com/ontology/content/ImageSet"
+      },
+      {
+        "accessLevel": "subscribed",
+        "alternativeImages": {},
+        "alternativeStandfirsts": {},
+        "alternativeTitles": {},
+        "bodyXML": "<body><p>”Fallback content” for this IG story will be contained within the body.</p>\n</body>",
+        "brands": [
+          "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+        ],
+        "byline": "",
+        "canBeDistributed": "verify",
+        "canBeSyndicated": "verify",
+        "comments": {
+          "enabled": true
+        },
+        "editorialDesk": "/FT/WorldNews",
+        "firstPublishedDate": "2018-05-16T16:23:06.000Z",
+        "id": "http://www.ft.com/thing/d02886fc-58ff-11e8-9859-6668838a4c10",
+        "identifiers": [
+          {
+            "authority": "http://api.ft.com/system/FTCOM-IG",
+            "identifierValue": "ccac6b68-d688-41f8-9209-31e4b4900b1b"
+          },
+          {
+            "authority": "http://api.ft.com/system/FTCOM-METHODE",
+            "identifierValue": "d02886fc-58ff-11e8-9859-6668838a4c10"
+          }
+        ],
+        "lastModified": "2018-06-19T12:55:14.074Z",
+        "publishReference": "tid_w3vmoogotb",
+        "publishedDate": "2018-05-16T16:23:06.000Z",
+        "requestUrl": "http://test.api.ft.com/content/d02886fc-58ff-11e8-9859-6668838a4c10",
+        "standout": {
+          "editorsChoice": false,
+          "exclusive": false,
+          "scoop": false
+        },
+        "title": "Test IG Story (optional headline)",
+        "type": "http://www.ft.com/ontology/content/DynamicContent",
+        "webUrl": "https://www.ft.com/content/d02886fc-58ff-11e8-9859-6668838a4c10"
+      }
+    ],
+    "id": "http://www.ft.com/thing/22c0d426-1466-11e7-b0c1-37e417ee6c76",
+    "identifiers": [
+      {
+        "authority": "http://api.ft.com/system/FTCOM-METHODE",
+        "identifierValue": "22c0d426-1466-11e7-b0c1-37e417ee6c76"
+      }
+    ],
+    "lastModified": "2017-03-31T15:42:28.504Z",
+    "mainImage": {
+      "alternativeImages": {},
+      "alternativeStandfirsts": {},
+      "alternativeTitles": {},
+      "canBeDistributed": "verify",
+      "description": "sample description",
+      "id": "http://www.ft.com/thing/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+      "identifiers": [
+        {
+          "authority": "http://api.ft.com/system/FTCOM-METHODE",
+          "identifierValue": "639cd952-149f-11e7-2ea7-a07ecd9ac73f"
+        }
+      ],
+      "lastModified": "2017-03-29T19:39:31.361Z",
+      "members": [
+        {
+          "alternativeImages": {},
+          "alternativeStandfirsts": {},
+          "alternativeTitles": {},
+          "binaryUrl": "http://image-storage-location",
+          "canBeDistributed": "verify",
+          "copyright": {
+            "notice": "© Bloomberg"
+          },
+          "description": "sample description",
+          "id": "http://www.ft.com/thing/639cd952-149f-11e7-b0c1-37e417ee6c76",
+          "identifiers": [
+            {
+              "authority": "http://api.ft.com/system/FTCOM-METHODE",
+              "identifierValue": "639cd952-149f-11e7-b0c1-37e417ee6c76"
+            }
+          ],
+          "lastModified": "2017-03-29T19:39:31.361Z",
+          "pixelHeight": 1152,
+          "pixelWidth": 2048,
+          "publishReference": "tid_5ypvntzcpu",
+          "publishedDate": "2017-03-29T19:39:00.000Z",
+          "requestUrl": "http://api.ft.com/content/639cd952-149f-11e7-b0c1-37e417ee6c76",
+          "title": "",
+          "type": "http://www.ft.com/ontology/content/MediaResource"
+        }
+      ],
+      "publishReference": "tid_5ypvntzcpu",
+      "publishedDate": "2017-03-29T19:39:00.000Z",
+      "requestUrl": "http://api.ft.com/content/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+      "title": "",
+      "type": "http://www.ft.com/ontology/content/ImageSet"
+    },
+    "publishReference": "tid_ra4srof3qc",
+    "publishedDate": "2017-03-30T06:54:02.000Z",
+    "requestUrl": "http://api.ft.com/content/22c0d426-1466-11e7-b0c1-37e417ee6c76",
+    "standfirst": "sample standfirst",
+    "standout": {
+      "editorsChoice": false,
+      "exclusive": true,
+      "scoop": true
+    },
+    "title": "",
+    "type": "http://www.ft.com/ontology/content/Article"
+  }

--- a/test-resources/contentpreview-noimages-valid-response.json
+++ b/test-resources/contentpreview-noimages-valid-response.json
@@ -91,7 +91,8 @@
     ],
     "lastModified": "2017-03-31T15:42:28.504Z",
     "mainImage": {
-        "id": "http://api.ft.com/content/639cd952-149f-11e7-2ea7-a07ecd9ac73f"
+		"id": "http://www.ft.com/thing/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+		"apiUrl": "https://test.api.ft.com/content/b7c8e40e-73a7-11e8-17fc-56e8d19c9a20"
     },
     "publishReference": "tid_ra4srof3qc",
     "publishedDate": "2017-03-30T06:54:02.000Z",

--- a/test-resources/reader-content-valid-response-embeds-not-resolved.json
+++ b/test-resources/reader-content-valid-response-embeds-not-resolved.json
@@ -1,0 +1,189 @@
+{
+	"639cd952-149f-11e7-2ea7-a07ecd9ac73f": {
+	  "id": "http://www.ft.com/thing/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+	  "type": "http://www.ft.com/ontology/content/ImageSet",
+	  "title": "",
+	  "alternativeTitles": {},
+	  "alternativeStandfirsts": {},
+	  "description": "sample description",
+	  "publishedDate": "2017-03-29T19:39:00.000Z",
+	  "identifiers": [
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-METHODE",
+		  "identifierValue": "639cd952-149f-11e7-2ea7-a07ecd9ac73f"
+		}
+	  ],
+	  "members": [
+		{
+		  "id": "http://api.ft.com/content/639cd952-149f-11e7-b0c1-37e417ee6c76"
+		}
+	  ],
+	  "requestUrl": "http://api.ft.com/content/639cd952-149f-11e7-2ea7-a07ecd9ac73f",
+	  "alternativeImages": {},
+	  "publishReference": "tid_5ypvntzcpu",
+	  "lastModified": "2017-03-29T19:39:31.361Z",
+	  "canBeDistributed": "verify"
+	},
+	"639cd952-149f-11e7-b0c1-37e417ee6c76": {
+	  "id": "http://www.ft.com/thing/639cd952-149f-11e7-b0c1-37e417ee6c76",
+	  "type": "http://www.ft.com/ontology/content/MediaResource",
+	  "title": "",
+	  "alternativeTitles": {},
+	  "alternativeStandfirsts": {},
+	  "description": "sample description",
+	  "publishedDate": "2017-03-29T19:39:00.000Z",
+	  "identifiers": [
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-METHODE",
+		  "identifierValue": "639cd952-149f-11e7-b0c1-37e417ee6c76"
+		}
+	  ],
+	  "requestUrl": "http://api.ft.com/content/639cd952-149f-11e7-b0c1-37e417ee6c76",
+	  "binaryUrl": "http://image-storage-location",
+	  "pixelWidth": 2048,
+	  "pixelHeight": 1152,
+	  "alternativeImages": {},
+	  "copyright": {
+		"notice": "© Bloomberg"
+	  },
+	  "publishReference": "tid_5ypvntzcpu",
+	  "lastModified": "2017-03-29T19:39:31.361Z",
+	  "canBeDistributed": "verify"
+	},
+	"71231d3a-13c7-11e7-b0c1-37e417ee6c76": {
+	  "id": "http://www.ft.com/thing/71231d3a-13c7-11e7-b0c1-37e417ee6c76",
+	  "type": "http://www.ft.com/ontology/content/MediaResource",
+	  "title": "",
+	  "alternativeTitles": {},
+	  "alternativeStandfirsts": {},
+	  "description": "sample description",
+	  "publishedDate": "2017-03-29T18:28:00.000Z",
+	  "identifiers": [
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-METHODE",
+		  "identifierValue": "71231d3a-13c7-11e7-b0c1-37e417ee6c76"
+		}
+	  ],
+	  "requestUrl": "http://api.ft.com/content/71231d3a-13c7-11e7-b0c1-37e417ee6c76",
+	  "binaryUrl": "http://image-storage-location",
+	  "pixelWidth": 2048,
+	  "pixelHeight": 1152,
+	  "alternativeImages": {},
+	  "copyright": {
+		"notice": "© FT montage; Getty Images"
+	  },
+	  "publishReference": "tid_fsdgcbtcih",
+	  "lastModified": "2017-03-29T18:28:38.571Z",
+	  "canBeDistributed": "verify"
+	},
+	"0261ea4a-1474-11e7-1e92-847abda1ac65": {
+	  "id": "http://www.ft.com/thing/0261ea4a-1474-11e7-1e92-847abda1ac65",
+	  "type": "http://www.ft.com/ontology/content/ImageSet",
+	  "title": "",
+	  "alternativeTitles": {},
+	  "alternativeStandfirsts": {},
+	  "description": "sample description",
+	  "publishedDate": "2017-03-29T18:28:00.000Z",
+	  "identifiers": [
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-METHODE",
+		  "identifierValue": "0261ea4a-1474-11e7-1e92-847abda1ac65"
+		}
+	  ],
+	  "members": [
+		{
+		  "id": "http://api.ft.com/content/0261ea4a-1474-11e7-80f4-13e067d5072c"
+		}
+	  ],
+	  "requestUrl": "http://api.ft.com/content/0261ea4a-1474-11e7-1e92-847abda1ac65",
+	  "alternativeImages": {},
+	  "publishReference": "tid_4tjlxfiynp",
+	  "lastModified": "2017-03-29T18:28:38.623Z",
+	  "canBeDistributed": "verify"
+	},
+	"0261ea4a-1474-11e7-80f4-13e067d5072c": {
+	  "id": "http://www.ft.com/thing/0261ea4a-1474-11e7-80f4-13e067d5072c",
+	  "type": "http://www.ft.com/ontology/content/MediaResource",
+	  "title": "",
+	  "alternativeTitles": {},
+	  "alternativeStandfirsts": {},
+	  "description": "sample description",
+	  "publishedDate": "2017-03-29T18:28:00.000Z",
+	  "identifiers": [
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-METHODE",
+		  "identifierValue": "0261ea4a-1474-11e7-80f4-13e067d5072c"
+		}
+	  ],
+	  "requestUrl": "http://api.ft.com/content/0261ea4a-1474-11e7-80f4-13e067d5072c",
+	  "binaryUrl": "http://image-storage-location",
+	  "pixelWidth": 2048,
+	  "pixelHeight": 1152,
+	  "alternativeImages": {},
+	  "copyright": {
+		"notice": "© AFP"
+	  },
+	  "publishReference": "tid_4tjlxfiynp",
+	  "lastModified": "2017-03-29T18:28:38.623Z",
+	  "canBeDistributed": "verify"
+	},
+	"4723cb4e-027c-11e7-ace0-1ce02ef0def9": {
+	  "id": "http://www.ft.com/thing/4723cb4e-027c-11e7-ace0-1ce02ef0def9",
+	  "type": "http://www.ft.com/ontology/content/MediaResource",
+	  "alternativeTitles": {},
+	  "alternativeStandfirsts": {},
+	  "publishedDate": "2017-03-06T14:50:00.000Z",
+	  "identifiers": [
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-METHODE",
+		  "identifierValue": "4723cb4e-027c-11e7-ace0-1ce02ef0def9"
+		}
+	  ],
+	  "requestUrl": "http://api.ft.com/content/4723cb4e-027c-11e7-ace0-1ce02ef0def9",
+	  "binaryUrl": "http://image-storage-location",
+	  "alternativeImages": {},
+	  "publishReference": "tid_axufgrmrhm",
+	  "lastModified": "2017-03-06T14:50:50.298Z"
+	},
+	"d02886fc-58ff-11e8-9859-6668838a4c10": {
+	  "accessLevel": "subscribed",
+	  "alternativeImages": {},
+	  "alternativeStandfirsts": {},
+	  "alternativeTitles": {},
+	  "bodyXML": "<body><p>”Fallback content” for this IG story will be contained within the body.</p>\n</body>",
+	  "brands": [
+		"http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+	  ],
+	  "byline": "",
+	  "canBeDistributed": "verify",
+	  "canBeSyndicated": "verify",
+	  "comments": {
+		"enabled": true
+	  },
+	  "editorialDesk": "/FT/WorldNews",
+	  "firstPublishedDate": "2018-05-16T16:23:06.000Z",
+	  "id": "http://www.ft.com/thing/d02886fc-58ff-11e8-9859-6668838a4c10",
+	  "identifiers": [
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-IG",
+		  "identifierValue": "ccac6b68-d688-41f8-9209-31e4b4900b1b"
+		},
+		{
+		  "authority": "http://api.ft.com/system/FTCOM-METHODE",
+		  "identifierValue": "d02886fc-58ff-11e8-9859-6668838a4c10"
+		}
+	  ],
+	  "lastModified": "2018-06-19T12:55:14.074Z",
+	  "publishReference": "tid_w3vmoogotb",
+	  "publishedDate": "2018-05-16T16:23:06.000Z",
+	  "requestUrl": "http://test.api.ft.com/content/d02886fc-58ff-11e8-9859-6668838a4c10",
+	  "standout": {
+		"editorsChoice": false,
+		"exclusive": false,
+		"scoop": false
+	  },
+	  "title": "Test IG Story (optional headline)",
+	  "type": "http://www.ft.com/ontology/content/DynamicContent",
+	  "webUrl": "https://www.ft.com/content/d02886fc-58ff-11e8-9859-6668838a4c10"
+	}
+  }


### PR DESCRIPTION
This PR is part of a bigger story.

Given a Content with uuid A, the top level id should be `http://www.ft.com/thing/A`

The embeds, mainImage and leadImages
- apiUrl is `https://api.ft.com/{endpoint}/A`
- the id should be the same as its top level id: `http://www.ft.com/thing/A`

The apiUrl from the mainImage, leadImages and embeds fields will contain the value of the requestUrl that is returned by content-public-read.

This modification requires some changes to be made by the Next team (the people who are responsible for ft.com). Do not merge this PR if those changes haven't been implemented. Make sure you talk to @davidlintonattheft before trying to merge this.

PRs related to this story:
https://github.com/Financial-Times/content-public-read/pull/35
https://github.com/Financial-Times/api-policy-component/pull/44
https://github.com/Financial-Times/enriched-content-read-api/pull/13
https://github.com/Financial-Times/internal-content-api/pull/28
https://github.com/Financial-Times/unrolled-content-public-read/pull/4