### PR TITLE
Use separate affinity rules for EU and US

### DIFF
--- a/helm/content-unroller/app-configs/content-unroller_eks_delivery.yaml
+++ b/helm/content-unroller/app-configs/content-unroller_eks_delivery.yaml
@@ -9,3 +9,24 @@ content_store:
 
 content_path: /content
 internal_content_path: /internalcontent
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - content-unroller
+      topologyKey: "kubernetes.io/hostname"
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - enriched-content-read-api
+        topologyKey: "kubernetes.io/hostname"

--- a/helm/content-unroller/app-configs/content-unroller_eks_delivery_prod_us.yaml
+++ b/helm/content-unroller/app-configs/content-unroller_eks_delivery_prod_us.yaml
@@ -1,0 +1,22 @@
+# Values used for the deployed application.
+replicaCount: 2
+service:
+  name: content-unroller
+
+content_store:
+  app_name: content-public-read
+  host: http://content-public-read:8080
+
+content_path: /content
+internal_content_path: /internalcontent
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+              - us-east-1a
+

--- a/helm/content-unroller/app-configs/content-unroller_eks_delivery_staging_us.yaml
+++ b/helm/content-unroller/app-configs/content-unroller_eks_delivery_staging_us.yaml
@@ -1,0 +1,22 @@
+# Values used for the deployed application.
+replicaCount: 2
+service:
+  name: content-unroller
+
+content_store:
+  app_name: content-public-read
+  host: http://content-public-read:8080
+
+content_path: /content
+internal_content_path: /internalcontent
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+              - us-east-1a
+

--- a/helm/content-unroller/templates/deployment.yaml
+++ b/helm/content-unroller/templates/deployment.yaml
@@ -19,25 +19,7 @@ spec:
         visualize: "true"
     spec:
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ .Values.service.name }}
-            topologyKey: "kubernetes.io/hostname"
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - enriched-content-read-api
-              topologyKey: "kubernetes.io/hostname"
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: {{ .Values.service.name }}
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"


### PR DESCRIPTION
# Description

## Why

To test if the latency is going to improve if we place `internal-content-api`, `enriched-content-read-api`, `content-public-read`, `document-store-api`, and `content-unroller` in the same AZ in US.

## Anything, in particular, you'd like to highlight to reviewers

_I left the affinity rules for EU just like they were._ 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
